### PR TITLE
migrate db after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Migrate database
-        run: pnpm prisma db push
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-
       - name: Install Vercel CLI
         run: pnpm install --global vercel@latest
 
@@ -72,6 +67,11 @@ jobs:
 
       - name: Build Project Artifacts
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Migrate database
+        run: pnpm prisma db push
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Thanks for creating this ressource to help people know how to test things properly!

I looked over this action and you probably want to migrate the DB after the build has suceeded. The reasons for this are:
1. if your build would fail, the old deployed application could be incomptible with the already migrated DB
2. minimize the time from applying DB changes to the time your (newly deployed) application can actual use the new DB structure. 